### PR TITLE
base: [SQUASH] Allow to customize notification led light [2/2]

### DIFF
--- a/core/java/android/app/INotificationManager.aidl
+++ b/core/java/android/app/INotificationManager.aidl
@@ -150,4 +150,7 @@ interface INotificationManager
     ParceledListSlice getAppActiveNotifications(String callingPkg, int userId);
 
     void setMediaPlaying(boolean playing);
+
+    void forceShowLedLight(int color);
+    void forcePulseLedLight(int color, int onTime, int offTime);
 }

--- a/core/java/android/app/NotificationChannel.java
+++ b/core/java/android/app/NotificationChannel.java
@@ -67,6 +67,9 @@ public final class NotificationChannel implements Parcelable {
     private static final String ATT_IMPORTANCE = "importance";
     private static final String ATT_LIGHTS = "lights";
     private static final String ATT_LIGHT_COLOR = "light_color";
+    private static final String ATT_ON_TIME = "light_on_time";
+    private static final String ATT_OFF_TIME = "light_off_time";
+    private static final String ATT_ON_ZEN = "light_on_zen";
     private static final String ATT_VIBRATION = "vibration";
     private static final String ATT_VIBRATION_ENABLED = "vibration_enabled";
     private static final String ATT_SOUND = "sound";
@@ -123,12 +126,15 @@ public final class NotificationChannel implements Parcelable {
     };
 
     private static final int DEFAULT_LIGHT_COLOR = 0;
+    private static final int DEFAULT_ON_TIME = 0;
+    private static final int DEFAULT_OFF_TIME = 0;
     private static final int DEFAULT_VISIBILITY =
             NotificationManager.VISIBILITY_NO_OVERRIDE;
     private static final int DEFAULT_IMPORTANCE =
             NotificationManager.IMPORTANCE_UNSPECIFIED;
     private static final boolean DEFAULT_DELETED = false;
     private static final boolean DEFAULT_SHOW_BADGE = true;
+    private static final boolean DEFAULT_ON_ZEN = false;
 
     private final String mId;
     private String mName;
@@ -139,6 +145,9 @@ public final class NotificationChannel implements Parcelable {
     private Uri mSound = Settings.System.DEFAULT_NOTIFICATION_URI;
     private boolean mLights;
     private int mLightColor = DEFAULT_LIGHT_COLOR;
+    private int mLightOnTime = DEFAULT_ON_TIME;
+    private int mLightOffTime = DEFAULT_OFF_TIME;
+    private boolean mLightOnZen = DEFAULT_ON_ZEN;
     private long[] mVibration;
     private int mUserLockedFields;
     private boolean mVibrationEnabled;
@@ -206,6 +215,9 @@ public final class NotificationChannel implements Parcelable {
         }
         mAudioAttributes = in.readInt() > 0 ? AudioAttributes.CREATOR.createFromParcel(in) : null;
         mLightColor = in.readInt();
+        mLightOnTime = in.readInt();
+        mLightOffTime = in.readInt();
+        mLightOnZen = in.readBoolean();
         mBlockableSystem = in.readBoolean();
     }
 
@@ -257,6 +269,9 @@ public final class NotificationChannel implements Parcelable {
             dest.writeInt(0);
         }
         dest.writeInt(mLightColor);
+        dest.writeInt(mLightOnTime);
+        dest.writeInt(mLightOffTime);
+        dest.writeBoolean(mLightOnZen);
         dest.writeBoolean(mBlockableSystem);
     }
 
@@ -376,6 +391,39 @@ public final class NotificationChannel implements Parcelable {
      */
     public void setLightColor(int argb) {
         this.mLightColor = argb;
+    }
+
+    /**
+     * Sets the notification light ON time for notifications posted to this channel, if lights are
+     * {@link #enableLights(boolean) enabled} on this channel and the device supports that feature.
+     *
+     * Only modifiable before the channel is submitted to
+     * {@link NotificationManager#notify(String, int, Notification)}.
+     */
+    public void setLightOnTime(int time) {
+        this.mLightOnTime = time;
+    }
+
+    /**
+     * Sets the notification light OFF time for notifications posted to this channel, if lights are
+     * {@link #enableLights(boolean) enabled} on this channel and the device supports that feature.
+     *
+     * Only modifiable before the channel is submitted to
+     * {@link NotificationManager#notify(String, int, Notification)}.
+     */
+    public void setLightOffTime(int time) {
+        this.mLightOffTime = time;
+    }
+
+    /**
+     * Enable the notification light for notifications posted to this channel, if lights are
+     * {@link #enableLights(boolean) enabled} on this channel, Do Not Disturb is active, and the device supports that feature.
+     * @hide
+     * Only modifiable before the channel is submitted to
+     * {@link NotificationManager#notify(String, int, Notification)}.
+     */
+    public void setLightOnZen(boolean enabled) {
+        this.mLightOnZen = enabled;
     }
 
     /**
@@ -503,6 +551,31 @@ public final class NotificationChannel implements Parcelable {
     }
 
     /**
+     * Returns the notification light ON time for notifications posted to this channel. Irrelevant
+     * unless {@link #shouldShowLights()}.
+     */
+    public int getLightOnTime() {
+        return mLightOnTime;
+    }
+
+    /**
+     * Returns the notification light OFF time for notifications posted to this channel. Irrelevant
+     * unless {@link #shouldShowLights()}.
+     */
+    public int getLightOffTime() {
+        return mLightOffTime;
+    }
+
+    /**
+     * Returns whether the notification light is enabled when Do Not Disturb is active for notifications posted to this channel. Irrelevant
+     * unless {@link #shouldShowLights()}.
+     * @hide
+     */
+    public boolean shouldLightOnZen() {
+        return mLightOnZen;
+    }
+
+    /**
      * Returns whether notifications posted to this channel always vibrate.
      */
     public boolean shouldVibrate() {
@@ -601,6 +674,9 @@ public final class NotificationChannel implements Parcelable {
 
         enableLights(safeBool(parser, ATT_LIGHTS, false));
         setLightColor(safeInt(parser, ATT_LIGHT_COLOR, DEFAULT_LIGHT_COLOR));
+        setLightOnTime(safeInt(parser, ATT_ON_TIME, DEFAULT_ON_TIME));
+        setLightOffTime(safeInt(parser, ATT_OFF_TIME, DEFAULT_OFF_TIME));
+        setLightOnZen(safeBool(parser, ATT_ON_ZEN, DEFAULT_ON_ZEN));
         setVibrationPattern(safeLongArray(parser, ATT_VIBRATION, null));
         enableVibration(safeBool(parser, ATT_VIBRATION_ENABLED, false));
         setShowBadge(safeBool(parser, ATT_SHOW_BADGE, false));
@@ -702,6 +778,15 @@ public final class NotificationChannel implements Parcelable {
         if (getLightColor() != DEFAULT_LIGHT_COLOR) {
             out.attribute(null, ATT_LIGHT_COLOR, Integer.toString(getLightColor()));
         }
+        if (getLightOnTime() != DEFAULT_ON_TIME) {
+            out.attribute(null, ATT_ON_TIME, Integer.toString(getLightOnTime()));
+        }
+        if (getLightOffTime() != DEFAULT_OFF_TIME) {
+            out.attribute(null, ATT_OFF_TIME, Integer.toString(getLightOffTime()));
+        }
+        if (shouldLightOnZen()) {
+            out.attribute(null, ATT_ON_ZEN, Boolean.toString(shouldLightOnZen()));
+        }
         if (shouldVibrate()) {
             out.attribute(null, ATT_VIBRATION_ENABLED, Boolean.toString(shouldVibrate()));
         }
@@ -757,6 +842,9 @@ public final class NotificationChannel implements Parcelable {
         }
         record.put(ATT_LIGHTS, Boolean.toString(shouldShowLights()));
         record.put(ATT_LIGHT_COLOR, Integer.toString(getLightColor()));
+        record.put(ATT_ON_TIME, Integer.toString(getLightOnTime()));
+        record.put(ATT_OFF_TIME, Integer.toString(getLightOffTime()));
+        record.put(ATT_ON_ZEN, Boolean.toString(shouldLightOnZen()));
         record.put(ATT_VIBRATION_ENABLED, Boolean.toString(shouldVibrate()));
         record.put(ATT_USER_LOCKED, Integer.toString(getUserLockedFields()));
         record.put(ATT_VIBRATION, longArrayToString(getVibrationPattern()));
@@ -859,6 +947,9 @@ public final class NotificationChannel implements Parcelable {
         if (getLockscreenVisibility() != that.getLockscreenVisibility()) return false;
         if (mLights != that.mLights) return false;
         if (getLightColor() != that.getLightColor()) return false;
+        if (getLightOnTime() != that.getLightOnTime()) return false;
+        if (getLightOffTime() != that.getLightOffTime()) return false;
+        if (shouldLightOnZen() != that.shouldLightOnZen()) return false;
         if (getUserLockedFields() != that.getUserLockedFields()) return false;
         if (mVibrationEnabled != that.mVibrationEnabled) return false;
         if (mShowBadge != that.mShowBadge) return false;
@@ -895,6 +986,9 @@ public final class NotificationChannel implements Parcelable {
         result = 31 * result + (getSound() != null ? getSound().hashCode() : 0);
         result = 31 * result + (mLights ? 1 : 0);
         result = 31 * result + getLightColor();
+        result = 31 * result + getLightOnTime();
+        result = 31 * result + getLightOffTime();
+        result = 31 * result + (mLightOnZen ? 1 : 0);
         result = 31 * result + Arrays.hashCode(mVibration);
         result = 31 * result + getUserLockedFields();
         result = 31 * result + (mVibrationEnabled ? 1 : 0);
@@ -918,6 +1012,9 @@ public final class NotificationChannel implements Parcelable {
                 ", mSound=" + mSound +
                 ", mLights=" + mLights +
                 ", mLightColor=" + mLightColor +
+                ", mLightOnTime=" + mLightOnTime +
+                ", mLightOffTime=" + mLightOffTime +
+                ", mLightOnZen=" + mLightOnZen +
                 ", mVibration=" + Arrays.toString(mVibration) +
                 ", mUserLockedFields=" + mUserLockedFields +
                 ", mVibrationEnabled=" + mVibrationEnabled +

--- a/core/java/android/app/NotificationManager.java
+++ b/core/java/android/app/NotificationManager.java
@@ -1228,4 +1228,24 @@ public class NotificationManager {
             throw e.rethrowFromSystemServer();
         }
     }
+
+    /** @hide */
+    public void forceShowLedLight(int color) {
+        final INotificationManager service = getService();
+        try {
+            service.forceShowLedLight(color);
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
+
+    /** @hide */
+    public void forcePulseLedLight(int color, int onTime, int offTime) {
+        final INotificationManager service = getService();
+        try {
+            service.forcePulseLedLight(color, onTime, offTime);
+        } catch (RemoteException e) {
+            throw e.rethrowFromSystemServer();
+        }
+    }
 }

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1068,10 +1068,10 @@
     <color name="config_defaultNotificationColor">#ffffffff</color>
 
     <!-- Default LED on time for notification LED in milliseconds. -->
-    <integer name="config_defaultNotificationLedOn">500</integer>
+    <integer name="config_defaultNotificationLedOn">2000</integer>
 
     <!-- Default LED off time for notification LED in milliseconds. -->
-    <integer name="config_defaultNotificationLedOff">2000</integer>
+    <integer name="config_defaultNotificationLedOff">3500</integer>
 
     <!-- Default value for led color when battery is low on charge -->
     <integer name="config_notificationsBatteryLowARGB">0xFFFF0000</integer>

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -1081,7 +1081,7 @@ public class NotificationManagerService extends SystemService {
             ContentResolver resolver = getContext().getContentResolver();
             if (uri == null || NOTIFICATION_LIGHT_PULSE_URI.equals(uri)) {
                 boolean pulseEnabled = Settings.System.getIntForUser(resolver,
-                            Settings.System.NOTIFICATION_LIGHT_PULSE, 0, UserHandle.USER_CURRENT) != 0;
+                            Settings.System.NOTIFICATION_LIGHT_PULSE, 1, UserHandle.USER_CURRENT) != 0;
                 if (mNotificationPulseEnabled != pulseEnabled) {
                     mNotificationPulseEnabled = pulseEnabled;
                     updateNotificationPulse();
@@ -3101,6 +3101,16 @@ public class NotificationManagerService extends SystemService {
         public void setMediaPlaying(boolean playing) {
             mIsMediaPlaying = playing;
         }
+
+        @Override
+        public void forceShowLedLight(int color) {
+            forceShowLed(color);
+        }
+
+        @Override
+        public void forcePulseLedLight(int color, int onTime, int offTime) {
+            forcePulseLed(color, onTime, offTime);
+        }
     };
 
     private void applyAdjustment(NotificationRecord r, Adjustment adjustment) {
@@ -4204,6 +4214,22 @@ public class NotificationManagerService extends SystemService {
                     .setType(MetricsEvent.TYPE_OPEN)
                     .setSubtype((buzz ? 1 : 0) | (beep ? 2 : 0) | (blink ? 4 : 0)));
             EventLogTags.writeNotificationAlert(key, buzz ? 1 : 0, beep ? 1 : 0, blink ? 1 : 0);
+        }
+    }
+
+    private void forceShowLed(int color) {
+        if (color != -1) {
+            mNotificationLight.setColor(color);
+        } else {
+            mNotificationLight.turnOff();
+        }
+    }
+
+    private void forcePulseLed(int color, int onTime, int offTime) {
+        if (color != -1) {
+            mNotificationLight.setFlashing(color, Light.LIGHT_FLASH_TIMED, onTime, offTime);
+        } else {
+            mNotificationLight.turnOff();
         }
     }
 

--- a/services/core/java/com/android/server/notification/NotificationRecord.java
+++ b/services/core/java/com/android/server/notification/NotificationRecord.java
@@ -132,6 +132,7 @@ public final class NotificationRecord {
     private boolean mShowBadge;
     private LogMaker mLogMaker;
     private Light mLight;
+    private boolean mLightOnZen;
     private String mGroupLogTag;
     private String mChannelIdLogTag;
 
@@ -156,6 +157,7 @@ public final class NotificationRecord {
         mImportance = calculateImportance();
         mLight = calculateLights();
         mAdjustments = new ArrayList<>();
+        mLightOnZen = calculateLightOnZen();
     }
 
     private boolean isPreChannelsNotification() {
@@ -198,32 +200,48 @@ public final class NotificationRecord {
 
     private Light calculateLights() {
         // Lineage lights will set the default color later
-        int defaultLightColor = 0;
+        // int defaultLightColor = 0;
+        int defaultLightColor = mContext.getResources().getColor(
+                 com.android.internal.R.color.config_defaultNotificationColor);
         int defaultLightOn = mContext.getResources().getInteger(
                 com.android.internal.R.integer.config_defaultNotificationLedOn);
         int defaultLightOff = mContext.getResources().getInteger(
                 com.android.internal.R.integer.config_defaultNotificationLedOff);
 
-        int channelLightColor = getChannel().getLightColor() != 0 ? getChannel().getLightColor()
+        int userSetLightColor = getChannel().getLightColor();
+        int userSetLightOnTime = getChannel().getLightOnTime();
+        int userSetLightOffTime = getChannel().getLightOffTime();
+        int channelLightColor = userSetLightColor != 0 ? userSetLightColor
                 : defaultLightColor;
+        int channelLightOnTime = userSetLightOnTime != 0 ? userSetLightOnTime
+                : defaultLightOn;
+        int channelLightOffTime = userSetLightOffTime != 0 ? userSetLightOffTime
+                : defaultLightOff;
         Light light = getChannel().shouldShowLights() ? new Light(channelLightColor,
-                defaultLightOn, defaultLightOff) : null;
+                channelLightOnTime, channelLightOffTime) : null;
+
         if (mPreChannelsNotification
                 && (getChannel().getUserLockedFields()
                 & NotificationChannel.USER_LOCKED_LIGHTS) == 0) {
             final Notification notification = sbn.getNotification();
             if ((notification.flags & Notification.FLAG_SHOW_LIGHTS) != 0) {
-                light = new Light(notification.ledARGB, notification.ledOnMS,
-                        notification.ledOffMS);
+                light = new Light(userSetLightColor != 0 ? userSetLightColor : notification.ledARGB,
+                        userSetLightOnTime != 0 ? userSetLightOnTime : notification.ledOnMS,
+                        userSetLightOffTime != 0 ? userSetLightOffTime : notification.ledOffMS);
                 if ((notification.defaults & Notification.DEFAULT_LIGHTS) != 0) {
-                    light = new Light(defaultLightColor, defaultLightOn,
-                            defaultLightOff);
+                    light = new Light(userSetLightColor != 0 ? userSetLightColor : defaultLightColor,
+                        userSetLightOnTime != 0 ? userSetLightOnTime : defaultLightOn,
+                        userSetLightOffTime != 0 ? userSetLightOffTime : defaultLightOff);
                 }
             } else {
                 light = null;
             }
         }
         return light;
+    }
+
+    private boolean calculateLightOnZen() {
+        return getChannel().shouldLightOnZen();
     }
 
     private long[] calculateVibration() {
@@ -853,6 +871,10 @@ public final class NotificationRecord {
 
     public Light getLight() {
         return mLight;
+    }
+
+    public boolean shouldLightOnZen() {
+        return mLightOnZen;
     }
 
     public Uri getSound() {


### PR DESCRIPTION
idea from: https://gerrit.omnirom.org/#/c/25822/
Author ezio84 <brabus84@gmail.com> Sep 16, 2017 9:11 PM
Commit 14eb38d77d7e39bcedbd5008c96347a7278098f1

* Allow to customize notification led light [2/2]
commit 0257afbe0cf306f4997daffed3b5d32e223e48cd

* Notification light: light during DND option [1/2]
commit a6132c5cf9e69c4117866d6afda798ea8efb1086

* Enable notifications led light by default [1/2]
commit 40b428b79584a896d8dde80543441c28a0873a5f

* Notification lights: use default resources for color on and off [2/2]
commit 328464e524e3cc2e18b348c11a681b3eac097363

* Notification light: update from abc
commit 7051bc114b4f2582ce9eb64f18e1224578a4a50a

* Add api to force show led lights
commit 5958780f841347cea51cc9f97f4528170e1c05fe