### PR TITLE
Fix OnePlusCamera

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -15,6 +15,18 @@
  */
 
 package android.hardware;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.impl.CameraMetadataNative;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.CaptureRequest.Builder;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.impl.CaptureResultExtras;
+import android.hardware.camera2.CameraManager;
+import android.content.Context;
+import java.lang.System;
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import android.hardware.ICameraService;
 
 import static android.system.OsConstants.*;
 
@@ -33,6 +45,7 @@ import android.os.Looper;
 import android.os.Message;
 import android.os.RemoteException;
 import android.os.ServiceManager;
+import android.os.SystemProperties;
 import android.renderscript.Allocation;
 import android.renderscript.Element;
 import android.renderscript.RSIllegalArgumentException;
@@ -190,6 +203,81 @@ public class Camera {
     private CameraDataCallback mCameraDataCallback;
     private CameraMetaDataCallback mCameraMetaDataCallback;
     /* ### QC ADD-ONS: END */
+
+    private static final int CAMERA_MSG_AEC = 0x4000;
+    private static final int CAMERA_MSG_DNG_IMAGE= 0x8000;
+    private static final int CAMERA_MSG_DNG_META_DATA = 0x10000;
+    private static final int CAMERA_MSG_IN_PROCESSING = 0x20000;
+    private static final int CAMERA_MSG_RAW_IMAGE_DUMMY = 0x40000;
+
+    private static CameraMetadataNative mMetadata;
+    private long mMetadataPtr; 
+    private CameraCharacteristics mCharacteristics;
+    private android.hardware.Camera.AECallback mAECallback;
+    private android.hardware.Camera.OneplusCallback mOneplusCallback;
+    private android.hardware.Camera.ProcessCallback mProcessCallback;
+    private boolean mIsOPService = false;
+    private android.hardware.Camera.PictureCallback mOPServiceJpegCallback = null;
+
+    public interface AECallback {
+
+        public abstract void onAEChanged(int[] p1, Camera p2);
+
+    }
+
+    public interface OneplusCallback {
+
+        public abstract void onDngImage(byte[] p1, Camera p2);
+
+        public abstract void onDngMetadata(CameraCharacteristics p1, CaptureResult p2, Camera p3);
+
+    }
+
+    public interface ProcessCallback {
+
+        public abstract void onProcess();
+
+    }
+    public void setAECallback(AECallback cb) {
+        mAECallback = cb;
+    }
+    
+    public final void setOneplusCallback(OneplusCallback cb) {
+        mOneplusCallback = cb;
+    }
+    
+    public final void setProcessCallback(ProcessCallback cb) {
+        mProcessCallback = cb;
+    }
+    
+    public void setOPJpegCallback(PictureCallback cb) {
+        mOPServiceJpegCallback = cb;
+    }
+    
+    public final void addDngImageCallbackBuffer(byte[] cb) {
+        addRawImageCallbackBuffer(cb);
+    }
+    
+    public static Camera openOPService() {
+        return null;//return new Camera(-0x1, -0x64);
+    }
+
+    private void getNativeCameraMetadata(int camID){
+    try{
+        ActivityThread am = ActivityThread.currentActivityThread();
+    
+        CameraManager manager = (CameraManager) am.
+        getApplication()
+        .getSystemService(Context.CAMERA_SERVICE);
+        String [] a=manager.getCameraIdList();
+        mCharacteristics = manager.getCameraCharacteristics(a[camID]);
+
+        }catch(Exception exc){
+            Log.e(TAG,"getNativeCameraMetadata error");
+            mCharacteristics = null;
+        }                
+
+    }
 
     /**
      * Broadcast Action:  A new picture is taken by the camera, and the entry of
@@ -505,6 +593,8 @@ public class Camera {
         mCameraDataCallback = null;
         mCameraMetaDataCallback = null;
         /* ### QC ADD-ONS: END */
+	mOneplusCallback = null;
+        mProcessCallback = null;
 
         Looper looper;
         if ((looper = Looper.myLooper()) != null) {
@@ -515,8 +605,23 @@ public class Camera {
             mEventHandler = null;
         }
 
-        return native_setup(new WeakReference<Camera>(this), cameraId, halVersion,
-                ActivityThread.currentOpPackageName());
+        String packageName = ActivityThread.currentOpPackageName();
+
+        //Force HAL1 if the package name falls in this bucket
+        String packageList = SystemProperties.get("camera.hal1.packagelist", "");
+        if (packageList.length() > 0) {
+            TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
+            splitter.setString(packageList);
+            for (String str : splitter) {
+                if (packageName.equals(str)) {
+                    halVersion = CAMERA_HAL_API_VERSION_1_0;
+                    break;
+                }
+            }
+        } else if (packageName.equals("com.oneplus.camera")) {
+	    halVersion = CAMERA_HAL_API_VERSION_1_0;
+	}
+        return native_setup(new WeakReference<Camera>(this), cameraId, halVersion, packageName);
     }
 
     private int cameraInitNormal(int cameraId) {
@@ -801,6 +906,7 @@ public class Camera {
         mRawImageCallback = null;
         mPostviewCallback = null;
         mJpegCallback = null;
+	mProcessCallback = null;
         synchronized (mAutoFocusCallbackLock) {
             mAutoFocusCallback = null;
         }
@@ -1147,7 +1253,13 @@ public class Camera {
 
         @Override
         public void handleMessage(Message msg) {
-            switch(msg.what) {
+            int msgID=msg.what;
+
+            if(msgID==CAMERA_MSG_RAW_IMAGE){
+                msgID=CAMERA_MSG_DNG_IMAGE;
+            }
+
+            switch(msgID) {
             case CAMERA_MSG_SHUTTER:
                 if (mShutterCallback != null) {
                     mShutterCallback.onShutter();
@@ -1163,6 +1275,10 @@ public class Camera {
             case CAMERA_MSG_COMPRESSED_IMAGE:
                 if (mJpegCallback != null) {
                     mJpegCallback.onPictureTaken((byte[])msg.obj, mCamera);
+                }
+		else if(mIsOPService&&mOPServiceJpegCallback != null){
+                    Log.d(TAG,"op jpeg callback");
+                    mOPServiceJpegCallback.onPictureTaken((byte[])msg.obj, mCamera);
                 }
                 return;
 
@@ -1242,6 +1358,44 @@ public class Camera {
                 }
                 return;
             /* ### QC ADD-ONS: END */
+	    case CAMERA_MSG_RAW_IMAGE_DUMMY:
+                Log.d(TAG,"CAMERA_MSG_RAW_IMAGE_DUMMY");
+                return;
+
+            case CAMERA_MSG_AEC:
+                Log.d(TAG,"CAMERA_MSG_AEC");
+                if (mAECallback != null) {
+                    int [] states=new int[2];
+                    states[0]=msg.arg1;
+                    states[1]=msg.arg2;
+                    mAECallback.onAEChanged(states,mCamera);
+                }
+                return;
+
+            case CAMERA_MSG_DNG_IMAGE:
+                Log.d(TAG,"CAMERA_MSG_DNG_IMAGE");
+                if (mOneplusCallback != null) {
+                    mOneplusCallback.onDngImage((byte[])msg.obj, mCamera);
+                }
+                return;
+
+            case CAMERA_MSG_DNG_META_DATA:
+                Log.d(TAG,"CAMERA_MSG_DNG_META_DATA");
+                if (mOneplusCallback != null
+                    &&mMetadata!=null) {
+                    mCharacteristics = new CameraCharacteristics(new CameraMetadataNative(mMetadata));
+                    CaptureResult result=new CaptureResult(new CameraMetadataNative(mMetadata),-1);
+                    mOneplusCallback.onDngMetadata(mCharacteristics, result, mCamera);
+                }
+            return;
+
+            case CAMERA_MSG_IN_PROCESSING:
+                Log.d(TAG,"CAMERA_MSG_IN_PROCESSING");
+                if (mProcessCallback != null) {
+                    mProcessCallback.onProcess();
+                }
+                return;
+
             default:
                 Log.e(TAG, "Unknown message type " + msg.what);
                 return;
@@ -1522,14 +1676,32 @@ public class Camera {
         if (mShutterCallback != null) {
             msgType |= CAMERA_MSG_SHUTTER;
         }
-        if (mRawImageCallback != null) {
-            msgType |= CAMERA_MSG_RAW_IMAGE;
-        }
         if (mPostviewCallback != null) {
             msgType |= CAMERA_MSG_POSTVIEW_FRAME;
         }
         if (mJpegCallback != null) {
             msgType |= CAMERA_MSG_COMPRESSED_IMAGE;
+        }
+	//oneplus camera mod
+        if (mOneplusCallback != null) {
+            msgType |= CAMERA_MSG_DNG_META_DATA;
+            msgType |= CAMERA_MSG_DNG_IMAGE;
+            mMetadata = new CameraMetadataNative();
+
+            try{
+                java.lang.reflect.Field ptrField = CameraMetadataNative.class.  
+                getDeclaredField("mMetadataPtr");  
+                ptrField.setAccessible(true);
+                mMetadataPtr = (long) ptrField.get(mMetadata);
+                }
+                catch(Exception x){
+
+                };
+
+        }
+
+        if (mProcessCallback != null) {
+            msgType |= CAMERA_MSG_IN_PROCESSING;
         }
 
         native_takePicture(msgType);

--- a/core/java/android/hardware/camera2/CameraCharacteristics.java
+++ b/core/java/android/hardware/camera2/CameraCharacteristics.java
@@ -26,6 +26,7 @@ import android.util.Rational;
 
 import java.util.Collections;
 import java.util.List;
+import android.app.ActivityThread;
 
 /**
  * <p>The properties describing a
@@ -204,6 +205,12 @@ public final class CameraCharacteristics extends CameraMetadata<CameraCharacteri
      */
     @Nullable
     public <T> T get(Key<T> key) {
+        if(key == INFO_SUPPORTED_HARDWARE_LEVEL){
+            String packageName = ActivityThread.currentOpPackageName();
+            if(packageName.equals("com.oneplus.camera")){
+                return (T)new Integer(0x2);
+            }
+        }
         return mProperties.get(key);
     }
 

--- a/core/jni/android_hardware_Camera.cpp
+++ b/core/jni/android_hardware_Camera.cpp
@@ -43,6 +43,7 @@ enum {
 
 struct fields_t {
     jfieldID    context;
+    jfieldID    metadata_ptr;
     jfieldID    facing;
     jfieldID    orientation;
     jfieldID    canDisableShutterSound;
@@ -66,6 +67,7 @@ struct fields_t {
 
 static fields_t fields;
 static Mutex sLock;
+static CameraMetadata* mMeta_ptr;
 
 // provides persistent context for calls from native code to Java
 class JNICameraContext: public CameraListener
@@ -276,7 +278,12 @@ void JNICameraContext::copyAndPost(JNIEnv* env, const sp<IMemory>& dataPtr, int 
                         return;
                     }
                 }
-            } else {
+            } else if(msgType == 0x10000) {
+                camera_metadata_t * cMetaData = reinterpret_cast<camera_metadata_t*>(heapBase + offset);
+                *mMeta_ptr=(const camera_metadata_t*)cMetaData;
+                mMeta_ptr->sort();
+            }
+            else {
                 ALOGV("Allocating callback buffer");
                 obj = env->NewByteArray(size);
             }
@@ -896,6 +903,7 @@ static void android_hardware_Camera_takePicture(JNIEnv *env, jobject thiz, jint 
     JNICameraContext* context;
     sp<Camera> camera = get_native_camera(env, thiz, &context);
     if (camera == 0) return;
+    mMeta_ptr=reinterpret_cast<android::CameraMetadata*>(env->GetLongField(thiz,fields.metadata_ptr));
 
     /*
      * When CAMERA_MSG_RAW_IMAGE is requested, if the raw image callback
@@ -1221,6 +1229,7 @@ int register_android_hardware_Camera(JNIEnv *env)
 {
     field fields_to_find[] = {
         { "android/hardware/Camera", "mNativeContext",   "J", &fields.context },
+        { "android/hardware/Camera", "mMetadataPtr",   "J", &fields.metadata_ptr },
         { "android/hardware/Camera$CameraInfo", "facing",   "I", &fields.facing },
         { "android/hardware/Camera$CameraInfo", "orientation",   "I", &fields.orientation },
         { "android/hardware/Camera$CameraInfo", "canDisableShutterSound",   "Z",


### PR DESCRIPTION
All credits to @siankatabg, @kxzxxx and @amirzaidi

* Force Onepluscamera to use HAL1
thx to @siankatab commits from nougat

ZeNiXxX committed on 19 Jan
https://github.com/Unleash-OS/android_frameworks_base/commit/040dbc22cf76ee805d669ac03f4260e8bb480b91

* FB: Make OnePlus Camera to coexists with HAL3

Change-Id: I7cedffe82eb3ab8b0807ef76301fca4edfc1416a
siankatabg committed on 11 Aug 2017
https://github.com/siankatabg/android_frameworks_base/commit/755be4d9d057495c269dfbc680b8c4be407c2772

* FB: Add the needed stuffs for OnePlusCamera to work
All credits to @kxzxxx for this. You can find his patch here:
kxzxxx/android_device_oneplus_oneplus3t@9bfb675

Change-Id: I8bf1179a892c430fd00ec423ccce14dd964a569c
siankatabg committed on 11 Aug 2017
https://github.com/siankatabg/android_frameworks_base/commit/16f3f7ee43c4ad6fbe02b7a18305042b99a97c79

* FB: Fix raw capturing and add smile support

Change-Id: I3a36f61cd68784f0f85a72386e515bf293087a7c
siankatabg committed on 11 Aug 2017
https://github.com/siankatabg/android_frameworks_base/commit/f5103cc736fc282373825bd27d686cdbf5fd0a33